### PR TITLE
feat: item detail page parallel & intercepting routes

### DIFF
--- a/app/@modal/(.)item/[itemId]/page.tsx
+++ b/app/@modal/(.)item/[itemId]/page.tsx
@@ -1,0 +1,23 @@
+import ItemContainer from "components/Item/ItemContainer";
+import Modal from "components/common/Modal";
+import React from "react";
+
+type Params = { params: { itemId: string } };
+
+const getItemData = async (itemId: number) => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_URI}/con-items//${itemId}`,
+    { cache: "no-store" }
+  );
+  const data = await res.json();
+  return data.conItem;
+};
+
+export default async function ({ params: { itemId } }: Params) {
+  const itemInfo = await getItemData(Number(itemId));
+  return (
+    <Modal>
+      <ItemContainer item={itemInfo}></ItemContainer>
+    </Modal>
+  );
+}

--- a/app/@modal/default.tsx
+++ b/app/@modal/default.tsx
@@ -1,0 +1,5 @@
+export const Default = () => {
+  return null;
+};
+
+export default Default;

--- a/app/layout.module.css
+++ b/app/layout.module.css
@@ -5,6 +5,7 @@
 
 .content {
   max-width: 627px;
+  min-height: 100vh;
   padding-top: 80px;
   margin: 0 auto;
   background-color: #f1f3f4;

--- a/app/layout.module.css
+++ b/app/layout.module.css
@@ -5,8 +5,7 @@
 
 .content {
   max-width: 627px;
-  padding: 80px 0 20px;
+  padding-top: 80px;
   margin: 0 auto;
   background-color: #f1f3f4;
-  min-height: 100vh;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,15 +3,20 @@ import styles from "./layout.module.css";
 import { Registry } from "./ui/Registry";
 export default function RootLayout({
   children,
+  modal,
 }: {
   children: React.ReactNode;
+  modal: React.ReactNode;
 }) {
   return (
     <html lang="ko">
       <body>
         <Registry>
           <div className={styles.main}>
-            <div className={styles.content}>{children}</div>
+            <div className={styles.content}>
+              {children}
+              {modal}
+            </div>
           </div>
         </Registry>
       </body>

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -26,13 +26,15 @@ const Loading = () => {
 };
 
 const StyledLoading = styled.div`
-  height: 100%;
+  height: 100vh;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  position: relative;
 `;
 
 const SpinnerSVG = styled.svg`
+  position: absolute;
+  top: 50%;
+  left: 50%;
   width: 32px;
   height: 32px;
   fill: gray;

--- a/components/Item/ItemDetail.tsx
+++ b/components/Item/ItemDetail.tsx
@@ -13,29 +13,9 @@ const ItemDetail = ({ item }: IProps) => {
   const [selectOption, setSelectOption] = useState<string>("");
   const listRef = useRef<HTMLDivElement>(null);
   const handleMenu = () => {
-    if (!listRef || !listRef.current) {
-      return;
-    }
-    const style = listRef.current.style;
-    if (isMenu) {
-      style.maxHeight = "0";
-    } else if (!isMenu) {
-      style.maxHeight = `${listRef.current.scrollHeight}px`;
-    }
-    if (isMenu) {
-      if (!selectOption) {
-        setIsMenu(!isMenu);
-        return;
-      }
-    }
-
     setIsMenu(!isMenu);
   };
 
-  const onSetIsVisible = () => {
-    setIsMenu(false);
-    handleMenu();
-  };
   return (
     <DetailContainer isMenu={isMenu}>
       <DetailContent>
@@ -53,7 +33,6 @@ const ItemDetail = ({ item }: IProps) => {
         setSelectOption={setSelectOption}
         setIsMenu={setIsMenu}
       />
-      {isMenu && <BodyBlackStyle onClick={onSetIsVisible} />}
     </DetailContainer>
   );
 };
@@ -61,16 +40,18 @@ const ItemDetail = ({ item }: IProps) => {
 const DetailContainer = styled.div<{ isMenu: boolean }>`
   display: flex;
   flex-direction: column;
-  width: 627px;
+  justify-content: space-between;
   height: 100%;
   background-color: #ffffff;
-  min-height: calc(100vh - 220px);
+  min-height: calc(100vh - 191px);
 `;
 
 const DetailContent = styled.div`
   display: flex;
   flex-direction: column;
   padding: 20px;
+  max-height: 300px;
+  overflow-y: auto;
 `;
 
 const DetailInfo = styled.span`
@@ -78,18 +59,6 @@ const DetailInfo = styled.span`
   white-space: pre-wrap;
   line-height: 1.5;
   color: #999;
-  margin-bottom: 2rem;
-`;
-
-export const BodyBlackStyle = styled.div`
-  width: 627px;
-  height: 100%;
-  position: fixed;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 1;
-  background-color: rgba(0, 0, 0, 0.4);
 `;
 
 export default ItemDetail;

--- a/components/Item/optionBox.tsx
+++ b/components/Item/optionBox.tsx
@@ -49,30 +49,32 @@ const OptionBox = ({
 
   return (
     <div className="optionBox">
-      <OptionList ref={listRef}>
-        <OptionWrapper>
-          {optionList.map((item, index) => (
-            <ListContainer
-              className="listContainer"
-              key={index}
-              index={index}
-              onClick={() => handleItem(item)}
-            >
-              <ListContent>
-                <ListComponent>
-                  <span className="title">유효기간:</span>
-                  <span>{item.expireAt} 까지</span>
-                </ListComponent>
-                <ListComponent>
-                  <span className="title">할인가:</span>
-                  <span> {item.sellingPrice.toLocaleString()}원</span>
-                </ListComponent>
-              </ListContent>
-              <ListRate>{discount}%</ListRate>
-            </ListContainer>
-          ))}
-        </OptionWrapper>
-      </OptionList>
+      {isMenu && (
+        <OptionList ref={listRef}>
+          <OptionWrapper>
+            {optionList.map((item, index) => (
+              <ListContainer
+                className="listContainer"
+                key={index}
+                index={index}
+                onClick={() => handleItem(item)}
+              >
+                <ListContent>
+                  <ListComponent>
+                    <span className="title">유효기간:</span>
+                    <span>{item.expireAt} 까지</span>
+                  </ListComponent>
+                  <ListComponent>
+                    <span className="title">할인가:</span>
+                    <span> {item.sellingPrice.toLocaleString()}원</span>
+                  </ListComponent>
+                </ListContent>
+                <ListRate>{discount}%</ListRate>
+              </ListContainer>
+            ))}
+          </OptionWrapper>
+        </OptionList>
+      )}
       {selectOption && (
         <SelectOptionContainer onClick={handleMenu}>
           <SelectBox>{selectOption}</SelectBox>
@@ -85,21 +87,12 @@ const OptionBox = ({
   );
 };
 
-const OptionList = styled.div`
-  max-height: 0;
-  position: fixed;
-  bottom: 50px;
-  width: 627px;
-  background-color: #ffffff;
-  overflow: hidden;
-  transition: max-height 0.3s ease;
-  z-index: 5;
-`;
+const OptionList = styled.div``;
 
 const OptionWrapper = styled.div`
   width: 100%;
-  min-height: 256px;
-  max-height: 256px;
+  border-top: 2px solid rgba(0, 0, 0, 0.1);
+  height: 150px;
   overflow-y: auto;
 `;
 
@@ -107,12 +100,7 @@ const ListContainer = styled.div<{ index: number }>`
   display: flex;
   justify-content: space-between;
   color: #000;
-  padding: 10px 20px;
-  ${({ index }) =>
-    index === 0 &&
-    css`
-      border-top: 2px solid rgba(0, 0, 0, 0.1);
-    `}
+  padding: 3px 20px;
 
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   cursor: pointer;
@@ -140,8 +128,6 @@ const ListRate = styled.span`
 `;
 
 const SelectOptionContainer = styled.div`
-  position: fixed;
-  width: 627px;
   background-color: #ffffff;
   border-top: 1px solid rgba(0, 0, 0, 0.2);
   bottom: 50px;
@@ -150,22 +136,22 @@ const SelectOptionContainer = styled.div`
 
 const SelectBox = styled.div`
   padding: 12px 20px;
-  margin: 15px 25px;
+  margin: 10px 25px;
   font-size: 15px;
   border-radius: 5px;
   background-color: #ebeced;
 `;
 
 const ButtonBuy = styled.button<{ isMenu: boolean }>`
-  position: fixed;
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 627px;
-  bottom: 0;
+  width: 100%;
   height: 50px;
-  z-index: 2;
+  transition: all 0.15s ease-in-out;
   color: #fff;
+  font-size: 17px;
+  font-weight: 600;
   ${({ isMenu }) =>
     isMenu
       ? css`

--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { useCallback, useRef, useEffect, MouseEventHandler } from "react";
+import { useRouter } from "next/navigation";
+import styled from "styled-components";
+
+export default function Modal({ children }: { children: React.ReactNode }) {
+  const overlay = useRef(null);
+  const wrapper = useRef(null);
+  const router = useRouter();
+
+  const onDismiss = useCallback(() => {
+    router.back();
+  }, [router]);
+
+  const onClick: MouseEventHandler = useCallback(
+    (e) => {
+      if (e.target === overlay.current || e.target === wrapper.current) {
+        if (onDismiss) onDismiss();
+      }
+    },
+    [onDismiss, overlay, wrapper]
+  );
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onDismiss();
+    },
+    [onDismiss]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onKeyDown]);
+
+  return (
+    <StyledModal ref={overlay} onClick={onClick}>
+      <Wrapper ref={wrapper}>{children}</Wrapper>
+    </StyledModal>
+  );
+}
+
+const StyledModal = styled.div`
+  position: fixed;
+  z-index: 10;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  margin-left: auto;
+  margin-right: auto;
+  background-color: rgba(0, 0, 0, 0.6);
+`;
+
+const Wrapper = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 70%;
+  max-width: 80%;
+  padding: 1.5rem;
+`;


### PR DESCRIPTION
## 구현 내용
- 상품 디테일 페이지 page parallel & intercepting routes 적용

`Soft Navigation` 으로 item/[itemId] 경로 이동시 app/@modal/(.)item 에서 경로를 가로채서 모달형식의 상품 상세페이지가 띄어짐
<img width="1063" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/9d930981-ce7e-4f8b-9e7b-9698eff2f4cb">

`Hard Navigation`으로 페이지 이동시 app/item/[itemId] 경로로 이동
<img width="1074" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/b85d800f-0c96-4601-8240-9c336c8e01c3">
