### PR TITLE
feat: on-demand revalidation 구현

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+
+export async function GET(request: NextRequest) {
+  const validatableTags = ["main", "itemList-items", "itemList-brand"];
+  const tag = request.nextUrl.searchParams.get("tag");
+  if (!tag || !validatableTags.includes(tag)) {
+    return NextResponse.json({ revalidated: false, status: 400 });
+  }
+  revalidateTag(tag);
+  return NextResponse.json({ revalidated: true, now: Date.now() });
+}

--- a/app/itemlist/[id]/page.tsx
+++ b/app/itemlist/[id]/page.tsx
@@ -9,7 +9,7 @@ type Params = { params: { id: string } };
 const getbrandItemList = async (id: string) => {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_URI}/con-items/?conCategory2Id=${id}`,
-    { next: { revalidate: 86400 } }
+    { next: { revalidate: 86400, tags: ["itemList-items"] } }
   );
   const data = await res.json();
   return data;
@@ -18,7 +18,7 @@ const getbrandItemList = async (id: string) => {
 const getBrandInfo = async (id: string): Promise<Brand> => {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_URI}/con-category2s/${id}`,
-    { next: { revalidate: 86400 } }
+    { next: { revalidate: 86400, tags: ["itemList-brand"] } }
   );
   const data = await res.json();
   return data;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,7 @@ const getCategoryData = async () => {
 
 const getSaleData = async () => {
   const res = await fetch(`${process.env.NEXT_PUBLIC_URI}/con-items/soon`, {
-    next: { revalidate: 86400 },
+    next: { revalidate: 86400, tags: ["main"] },
   });
   const data = await res.json();
   return data;

--- a/cypress/integration/app_spec.js
+++ b/cypress/integration/app_spec.js
@@ -39,7 +39,7 @@ describe("E2E Test", () => {
   });
 
   it("사용자는 상세페이지에서 구매하기 버튼을 눌러 옵션리스트들을 조회한 후 옵션을 선택할 수 있다.", () => {
-    cy.get(".optionBox").within(() => {
+    cy.get(".optionBox", { timeout: 10000 }).within(() => {
       cy.get(".buttonBuy").click();
       cy.get(".listContainer").first().click();
     });


### PR DESCRIPTION
## 구현내용
- app directory server component revalidate값으로 캐싱기간을 설정한 통신에 on-demand-revalidate 기능 구현


### main page test

### before
-PR에서 생성된 프리뷰에서 main page `revalidate=86400`으로 설정된 땡처리콘 데이터는 아래와 같이 캐싱되어 있었으며, 새로고침해도 동일한 데이터를 반환

<img width="658" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/2169f3a8-e9f6-4552-b3c9-6a85a394f1e4">

on-demand-revalidate 실패 case
<img width="717" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/8875d3e1-85a7-4974-a71f-fc4cb29b6d84">


#### on-demand-revalidate 적용 결과
<img width="705" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/a208123d-b192-4747-8cb1-4e5192796078">

after
- 캐싱된 데이터가 revalidate돼서 맨 아래 데이터가 업데이트 됐다.
<img width="749" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/97c13e7a-39c8-42c0-b3d0-a326c7247d56">



TODO:
dynamic route 인 itemlist 페이지 

### before
![image](https://github.com/hyjoong/ncnc/assets/70426440/cda71e9c-7e17-4eb9-bafa-8932236f380e)


network tab에서 `disabled cache ` 설정하고 강력 새로고침으로 해도 itemlist page 에서는 계속 캐시된 데이터를 반환한다.
<img width="1440" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/1ed1e1c2-4cfe-44ca-b6e0-bdc810960a8f">

on-demand-revalidate 방식을 통해 캐시된 데이터를 무효화

<img width="764" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/d7de7ec8-50ac-49b9-a8be-dd837e2447d5">

### after 
<img width="1440" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/9f3d8f88-bd52-48ce-aaee-7739d994c4e5">

