### PR TITLE
feat: error component 구현 (error.tsx, not-found.tsx)

### DIFF
--- a/app/@modal/(.)item/[itemId]/error.tsx
+++ b/app/@modal/(.)item/[itemId]/error.tsx
@@ -1,0 +1,38 @@
+"use client"; // Error components must be Client Components
+
+import { useEffect } from "react";
+import Modal from "components/common/Modal";
+import styled from "styled-components";
+
+export default function Error({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+  return (
+    <Modal>
+      <ErrorContainer>
+        <h2>상품 데이터를 불러올 수 없습니다!</h2>
+      </ErrorContainer>
+    </Modal>
+  );
+}
+
+const ErrorContainer = styled.div`
+  width: 60vw;
+  padding: 10px 30px;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 7px;
+
+  h2 {
+    color: #000000;
+    font-weight: 600;
+    font-size: 20px;
+  }
+`;

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Header from "components/common/Header";
+import Link from "next/link";
+import styles from "./layout.module.css";
+
+export default function NotFound() {
+  return (
+    <div className={styles.main}>
+      <Header title="not found" />
+      <div className={styles.content}>
+        <h2>Not Found</h2>
+        <p>The page you requested cannot be found</p>
+        <p>
+          <Link href="/">Return to the Main page</Link>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 상품 상세페이지 조회 실패시 error UI 표시 
- server component인  `app/@modal/('.')/[itemId]/page.tsx` 에서 `getItemData` 통신 실패시 아래 에러UI 표시

<img width="735" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/0645947d-e316-4f29-8a7b-5c4dc0721249">



## not found 경로 구현
- 404 에러 페이지 아래처럼 나타나게 구현 (디자인 수정 필요)
<img width="728" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/e26fb4a8-98c7-4489-be3a-3f66e27ff9ab">
