### PR TITLE
feat: itemList 페이지 useRouter -> next/link 적용

### DIFF
--- a/components/itemList/listItem.tsx
+++ b/components/itemList/listItem.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled, { css } from "styled-components";
 import { BrandItem } from "types";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 interface IProps {
   item: BrandItem;
@@ -11,36 +11,31 @@ interface IProps {
 }
 
 const ListItem = ({ item, type, id }: IProps) => {
-  const router = useRouter();
-  const HandlePage = () => {
-    if (type !== "detail") {
-      router.push(`/${type}/${id}`);
-    } else {
-      return;
-    }
-  };
+  const productItemRoute = type === "detail" ? "" : `/${type}/${id}`;
 
   return (
-    <CategoryBox className="itemListBox" onClick={HandlePage} type={type}>
-      <Image
-        src={item.imageUrl}
-        width={70}
-        height={70}
-        alt="sale-item"
-        placeholder="blur"
-        blurDataURL="data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=="
-      />
-      <ItemContent>
-        <ItemName>{item.name}</ItemName>
-        <ItemPrice>
-          <ItemDiscountRate>{item.discountRate}%</ItemDiscountRate>
-          <ItemSalePrice>
-            {item.minSellingPrice.toLocaleString()}원
-          </ItemSalePrice>
-          <ItemCost>{item.originalPrice.toLocaleString()}원</ItemCost>
-        </ItemPrice>
-      </ItemContent>
-    </CategoryBox>
+    <Link href={productItemRoute}>
+      <CategoryBox className="itemListBox" type={type}>
+        <Image
+          src={item.imageUrl}
+          width={70}
+          height={70}
+          alt="sale-item"
+          placeholder="blur"
+          blurDataURL="data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=="
+        />
+        <ItemContent>
+          <ItemName>{item.name}</ItemName>
+          <ItemPrice>
+            <ItemDiscountRate>{item.discountRate}%</ItemDiscountRate>
+            <ItemSalePrice>
+              {item.minSellingPrice.toLocaleString()}원
+            </ItemSalePrice>
+            <ItemCost>{item.originalPrice.toLocaleString()}원</ItemCost>
+          </ItemPrice>
+        </ItemContent>
+      </CategoryBox>
+    </Link>
   );
 };
 


### PR DESCRIPTION
## 📖 작업 배경

니콘내콘 `itemList` 페이지에서 특정 상품을 클릭하여 동적 경로인 `item` 페이지로 이동할 수 있다.

<img width="481" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/02cd60e6-53d8-4c5c-9d8f-6e2d736f58c1">

기존 코드에서는 `useRouter`을 통해 `router.push()`를 사용하여 페이지를 전환했다. 현재 스터디에서 다루는 주제중 하나인 `useRouter`와 `next/link`를 사용한 페이지 이동의 차이를 다루기 위해서 두 가지 방법에 대한 비교를 통해 어떤 방법이 더 효율적인지 알아보기로 했다.

## 📖 구현 내용
- useRouter ->`next/link`를 사용한 페이지 이동

### 1. useRouter을 사용했을 때 데이터 통신
<img width="1352" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/4cb7fe95-967e-4b0a-806d-c9d3edb933f1">

현재 페이지에서는 이미지 파일만 받아오고 상품 상세페이지에 대한 데이터는 prefetch하지 않는다

#### id=180 번인 스타벅스 카페라떼 상품을 클릭 하여 item/180 이동 했을 때
<img width="749" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/6c1d7d95-0a7e-41e4-b95b-69791e4becc5">

`854B`크기의 rsc 파일을 받아오는 것을 확인 할 수 있다.

### 2. next/link을 사용했을 때 데이터 통신
동적 경로로 작성된 item페이지의  레이아웃(layout.tsx) 파일이 prefetch 및 캐싱된 것을 확인할 수 있었다.

<img width="1436" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/30d8a9d0-37b4-4298-944a-1837dcb3f039">

- 페이지를 이동하지 않더라도 레이아웃에서 작성한 파일을 받아오는 것을 확인할 수 있다.
<img width="814" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/66ce6c96-9516-4651-833e-acd7a0d3f9c0">

#### id=180 번인 스타벅스 카페라떼 상품을 클릭 하여 item/180 이동 했을 때
<img width="1040" alt="image" src="https://github.com/hyjoong/ncnc/assets/70426440/9f1f80b9-b297-478d-8199-3bdc356b842e">
`635B`크기의 rsc 파일을 받아오는 것을 확인 할 수 있다

## 결과 
- 180번의 카페라떼 상품을 `next/link`를 사용하여 테스트한 결과, 상품 상세 페이지로 이동 시 파일의 크기가  854B -> 635B로 줄어든 것을 확인할 수 있었다
- `router`대신 `next/link`를 사용하면 prefetch의 기능을 활용할 수 있어서 상품 조회의 시간이 단축되어 사용자에게 좋은 경험을 줄 수 있을 것 같다 !


## 💡 참고사항

- 참고사항
- 궁금한 점

<br/>

## 🖼️ 스크린샷

<br/>
