### PR TITLE
Feat lighthouse ci google sheets

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,246 @@
+name: Run Lighthouse CI
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lhci:
+    name: Lighthouse CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 18.12.1
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.12.1
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: yarn-cache
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install packages
+        run: yarn install
+
+      - name: Build
+        run: yarn build
+
+      - name: Run Lighthouse CI for Desktop
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+        run: |
+          yarn global add @lhci/cli
+          lhci collect --config=lighthouserc-desktop.js || echo 'Fail to Run Lighthouse CI 💦'
+          lhci upload --config=lighthouserc-desktop.js || echo 'Fail to Run Lighthouse CI 💦'
+
+      - name: Run Lighthouse CI for Mobile
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+        run: |
+          lhci collect --config=lighthouserc-mobile.js || echo 'Fail to Run Lighthouse CI 💦'
+          lhci upload --config=lighthouserc-mobile.js || echo 'Fail to Run Lighthouse CI 💦'
+
+      - name: Format lighthouse score
+        id: format_lighthouse_score
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { getLhciPageNameFromUrl, LHCI_GREEN_MIN_SCORE, LHCI_ORANGE_MIN_SCORE, LHCI_RED_MIN_SCORE } = require('./src/configs/lighthouse/Lighthouse.js');
+
+            const getColor = (score) => {
+              if (score >= LHCI_GREEN_MIN_SCORE) return '🟢';
+              else if (score >= LHCI_ORANGE_MIN_SCORE) return '🟠';
+              return '🔴';
+            }
+
+            const getAuditColorAndScore = (score) => getColor(score) + score;
+            const getPerformanceMetricColorAndScore = (category) => getColor(category.score * 100) + category.displayValue;
+
+            const formatResult = (res) => Math.round(res * 100);
+
+            const desktopResults = JSON.parse(fs.readFileSync('path/to/desktop/results.json'));
+            const mobileResults = JSON.parse(fs.readFileSync('path/to/mobile/results.json'));
+
+            const monitoringTime = new Date().toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' });
+            const scoreDescription = `> 🟢: ${LHCI_GREEN_MIN_SCORE} - 100` + ' / ' + `🟠: ${LHCI_ORANGE_MIN_SCORE} - ${LHCI_GREEN_MIN_SCORE - 1}` + ' / ' + `🔴: ${LHCI_RED_MIN_SCORE} - ${LHCI_ORANGE_MIN_SCORE - 1}`;
+            let comments = '';
+
+            comments += `### Lighthouse report ✨\n`;
+            comments += `${scoreDescription}\n\n`;
+
+            const scores = { desktop: {}, mobile: {} };
+
+            const extractLhciResults = (results, device) => {
+              comments += `#### ${device}\n\n`;
+
+              results.forEach((result) => {
+                const { url, summary, jsonPath } = result;
+                const { audits } = JSON.parse(fs.readFileSync(jsonPath));
+
+                const pageUrl = url.replace('http://localhost:3000', '');
+                const pageName = getLhciPageNameFromUrl(pageUrl);
+
+                Object.keys(summary).forEach((key) => (summary[key] = formatResult(summary[key])));
+
+                const { performance, accessibility, 'best-practices': bestPractices, seo, pwa } = summary;
+                const { 'first-contentful-paint': firstContentfulPaint, 'largest-contentful-paint': largestContentfulPaint, 'speed-index': speedIndex, 'total-blocking-time': totalBlockingTime, 'cumulative-layout-shift': cumulativeLayoutShift } = audits;
+
+                const formattedScoreTable = [
+                  `| Category | Score |`,
+                  `| --- | --- |`,
+                  `| ${getColor(performance)} Performance | ${performance} |`,
+                  `| ${getColor(accessibility)} Accessibility | ${accessibility} |`,
+                  `| ${getColor(bestPractices)} Best practices | ${bestPractices} |`,
+                  `| ${getColor(seo)} SEO | ${seo} |`,
+                  `| ${getColor(pwa)} PWA | ${pwa} |`,
+                  `| ${getColor(firstContentfulPaint.score * 100)} First Contentful Paint | ${firstContentfulPaint.displayValue} |`,
+                  `| ${getColor(largestContentfulPaint.score * 100)} Largest Contentful Paint | ${largestContentfulPaint.displayValue} |`,
+                  `| ${getColor(speedIndex.score * 100)} Speed Index | ${speedIndex.displayValue} |`,
+                  `| ${getColor(totalBlockingTime.score * 100)} Total Blocking Time | ${totalBlockingTime.displayValue} |`,
+                  `| ${getColor(cumulativeLayoutShift.score * 100)} Cumulative Layout Shift | ${cumulativeLayoutShift.displayValue} |`,
+                  `\n`,
+                ].join('\n');
+
+                const score = {
+                  Performance: getAuditColorAndScore(performance),
+                  Accessibility: getAuditColorAndScore(accessibility),
+                  'Best Practices': getAuditColorAndScore(bestPractices),
+                  SEO: getAuditColorAndScore(seo),
+                  PWA: getAuditColorAndScore(pwa),
+                  FCP: getPerformanceMetricColorAndScore(firstContentfulPaint),
+                  LCP: getPerformanceMetricColorAndScore(largestContentfulPaint),
+                  'Speed Index': getPerformanceMetricColorAndScore(speedIndex),
+                  'TBT': getPerformanceMetricColorAndScore(totalBlockingTime),
+                  'CLS': getPerformanceMetricColorAndScore(cumulativeLayoutShift),
+                }
+                
+                scores[device][pageName] = score;
+
+                comments += `<details>\n<summary>${pageName}</summary>\n\n> ${pageUrl}\n\n${formattedScoreTable}\n</details>\n\n`;
+              });
+            } 
+
+            extractLhciResults(desktopResults, 'desktop');
+            extractLhciResults(mobileResults, 'mobile');
+
+            core.setOutput('comments', comments);            
+            core.setOutput('monitoringTime', monitoringTime);
+            core.setOutput('scores', scores);
+
+      - name: Comment PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+
+            const fs = require('fs');
+            const { Octokit } = require('@octokit/rest');
+            const octokit = new Octokit({ auth: `${{ secrets.GITHUB_TOKEN }}` });
+
+            const { repo, payload } = context;
+
+            const { data: previousComments } = await octokit.issues.listComments({
+              owner: repo.owner,
+              repo: repo.repo,
+              issue_number: payload.pull_request.number,
+            });
+
+            const previousLhciComment = previousComments.find((comment) => (comment.body.startsWith(`### Lighthouse report ✨\n`)));
+            const newComment = `${{ steps.format_lighthouse_score.outputs.comments }}`;
+
+            if (previousLhciComment) {
+              await octokit.issues.updateComment({
+                owner: repo.owner,
+                repo: repo.repo,
+                comment_id: previousLhciComment.id, 
+                body: newComment, 
+              });
+            } else { 
+              await octokit.issues.createComment({
+                owner: repo.owner,
+                repo: repo.repo,
+                issue_number: payload.pull_request.number,
+                body: newComment,
+              });
+            }
+
+        - name: Update Google Sheet
+        env:
+          GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
+        run: |
+          const { GoogleSpreadsheet } = require('google-spreadsheet');
+          const { monitoringTime, scores } = JSON.parse(process.env.COMMENTS_OUTPUT);
+          
+          const doc = new GoogleSpreadsheet('your-spreadsheet-id');
+          await doc.useServiceAccountAuth({
+            client_email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
+            private_key: process.env.GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n'),
+          });
+
+          await doc.loadInfo();
+
+          const getLhciSheetIdFromPageName = (pageName) => {
+            const sheetMap = {
+              'Page 1': 'sheet-id-1',
+              'Page 2': 'sheet-id-2',
+              // Add mappings as needed
+            };
+            return sheetMap[pageName];
+          };
+
+          const updateGoogleSheet = async () => {
+            for (const [pageName, score] of Object.entries(scores.desktop)) {
+              const sheetId = getLhciSheetIdFromPageName(pageName);
+
+              if (!sheetId) continue;
+
+              const sheet = doc.sheetsById[sheetId];
+              await sheet.loadHeaderRow();
+
+              const newRow = {
+                Date: monitoringTime,
+                'Desktop Performance': score.Performance,
+                'Desktop Accessibility': score.Accessibility,
+                'Desktop Best Practices': score['Best Practices'],
+                'Desktop SEO': score.SEO,
+                'Desktop PWA': score.PWA,
+                'Desktop FCP': score.FCP,
+                'Desktop LCP': score.LCP,
+                'Desktop Speed Index': score['Speed Index'],
+                'Desktop TBT': score.TBT,
+                'Desktop CLS': score.CLS,
+                'Mobile Performance': scores.mobile[pageName].Performance,
+                'Mobile Accessibility': scores.mobile[pageName].Accessibility,
+                'Mobile Best Practices': scores.mobile[pageName]['Best Practices'],
+                'Mobile SEO': scores.mobile[pageName].SEO,
+                'Mobile PWA': scores.mobile[pageName].PWA,
+                'Mobile FCP': scores.mobile[pageName].FCP,
+                'Mobile LCP': scores.mobile[pageName].LCP,
+                'Mobile Speed Index': scores.mobile[pageName]['Speed Index'],
+                'Mobile TBT': scores.mobile[pageName].TBT,
+                'Mobile CLS': scores.mobile[pageName].CLS,
+              };
+
+              await sheet.addRow(newRow);
+            }
+          };
+
+          updateGoogleSheet();

--- a/config/lighthouse/lighthouse.js
+++ b/config/lighthouse/lighthouse.js
@@ -30,7 +30,7 @@ module.exports = {
    * @param {string} url
    * @returns {string} 페이지 이름
    */
-  getLhciPageNameFromUrl(url: string): string | undefined {
+  getLhciPageNameFromUrl(url) {
     const decodedUrl = decodeURIComponent(url);
     return Object.keys(this.LHCI_PAGE_NAME_TO_URL).find(
       (name) =>

--- a/config/lighthouse/lighthouse.ts
+++ b/config/lighthouse/lighthouse.ts
@@ -1,0 +1,58 @@
+module.exports = {
+  LHCI_GOOGLE_SPREAD_SHEET_ID: "1AwekCNLh7PNe7SV62NRwqvyPyAy1gRr-3cW4i2t4nE0",
+
+  // Lighthouse 점수 색상 기준
+  LHCI_GREEN_MIN_SCORE: 90,
+  LHCI_ORANGE_MIN_SCORE: 50,
+  LHCI_RED_MIN_SCORE: 0,
+
+  // lighthouse 성능 측정할 페이지 이름 목록
+  LHCI_MONITORING_PAGE_NAMES: ["/", "brand", "itemlist", "item"],
+
+  // lighthouse 성능 측정할 페이지 이름 - url 매핑
+  LHCI_PAGE_NAME_TO_URL: {
+    MainPage: "/",
+    BrandPage: "/brand/67",
+    ItemListPage: "/itemlist/63",
+    ItemPage: "/item/137",
+  },
+
+  // lighthouse 성능 측정할 페이지 이름 - 시트 id 매핑
+  LHCI_PAGE_NAME_TO_SHEET_ID: {
+    MainPage: 0,
+    BrandPage: 1,
+    ItemListPage: 2,
+    ItemPage: 3,
+  },
+
+  /**
+   * 페이지 URL을 받아 페이지 이름을 반환
+   * @param {string} url
+   * @returns {string} 페이지 이름
+   */
+  getLhciPageNameFromUrl(url: string): string | undefined {
+    const decodedUrl = decodeURIComponent(url);
+    return Object.keys(this.LHCI_PAGE_NAME_TO_URL).find(
+      (name) =>
+        decodeURIComponent(this.LHCI_PAGE_NAME_TO_URL[name]) === decodedUrl,
+    );
+  },
+
+  /**
+   * 페이지 이름을 받아 페이지 URL을 반환
+   * @param {string} name
+   * @returns {string} 페이지 URL
+   */
+  getLhciUrlFromPageName: (name) => {
+    return module.exports.LHCI_PAGE_NAME_TO_URL[name];
+  },
+
+  /**
+   * 페이지 이름을 받아 시트 ID를 반환
+   * @param {string} name
+   * @returns {number} 시트 ID
+   */
+  getLhciSheetIdFromPageName: (name) => {
+    return module.exports.LHCI_PAGE_NAME_TO_SHEET_ID[name];
+  },
+};

--- a/lighthouserc-desktop.js
+++ b/lighthouserc-desktop.js
@@ -1,0 +1,23 @@
+const { LHCIConfig } = require("./config/lighthouse/lighthouse.ts");
+
+const urls = LHCIConfig.LHCI_MONITORING_PAGE_NAMES.map(
+  (name) => `https://ncnc.vercel.app${LHCIConfig.getLhciUrlFromPageName(name)}`,
+);
+
+module.exports = {
+  ci: {
+    collect: {
+      startServerCommand: "yarn run start",
+      url: urls,
+      numberOfRuns: 1,
+      settings: {
+        preset: "desktop",
+      },
+    },
+    upload: {
+      target: "filesystem",
+      outputDir: "./lhci_reports/desktop",
+      reportFilenamePattern: "%%PATHNAME%%-%%DATETIME%%-report.%%EXTENSION%%",
+    },
+  },
+};

--- a/lighthouserc-mobile.js
+++ b/lighthouserc-mobile.js
@@ -1,0 +1,20 @@
+const { LHCIConfig } = require("./config/lighthouse/lighthouse.ts");
+
+const urls = LHCIConfig.LHCI_MONITORING_PAGE_NAMES.map(
+  (name) => `https://ncnc.vercel.app${LHCIConfig.getLhciUrlFromPageName(name)}`,
+);
+
+module.exports = {
+  ci: {
+    collect: {
+      startServerCommand: "yarn run start",
+      url: urls,
+      numberOfRuns: 1,
+    },
+    upload: {
+      target: "filesystem",
+      outputDir: "./lhci_reports/mobile",
+      reportFilenamePattern: "%%PATHNAME%%-%%DATETIME%%-report.%%EXTENSION%%",
+    },
+  },
+};


### PR DESCRIPTION
## 📖 작업 배경
- Lighthouse CI와 Google Sheets를 연동하여 웹사이트 성능 측정 자동화 구현

## 📖 구현 내용

- GitHub Actions를 사용하여 Pull Request이 올라오면 Lighthouse CI를 실행하고 성능 측정 데이터를 수집
- 수집한 데이터를 Google Sheets에 업데이트하여 성능 지표를 시각화하고 추적

## 💡 참고사항

- 참고사항
- 궁금한 점

<br/>

## 🖼️ 스크린샷

<br/>
